### PR TITLE
Give errorcode variable external linkage

### DIFF
--- a/src/fond_internal.h
+++ b/src/fond_internal.h
@@ -19,7 +19,7 @@
 #  include <GL/glext.h>
 #endif
 
-int errorcode;
+extern int errorcode;
 void fond_err(int code);
 int fond_check_glerror();
 int fond_check_shader(GLuint shader);


### PR DESCRIPTION
Thanks for making this library. I recently packaged it for GNU guix (https://github.com/Tass0sm/tassos-guix/blob/master/tassos-guix/packages/gl.scm). I also couldn't compile it without changing "int errorcode;" to "extern int errorcode;" Is this change reasonable?